### PR TITLE
Mark code as no_run

### DIFF
--- a/src/chapter_1.md
+++ b/src/chapter_1.md
@@ -44,7 +44,7 @@ You will also need to implement a few standard library traits.
 
 ## Unit Tests
 
-```rust
+```rust,no_run
 {{#include tests/chunk_type_tests.rs}}
 ```
 


### PR DESCRIPTION
mdBook automatically wraps rust code in a main fn, such that it can be run on the playground. This extra code is also included when you use the copy button. An alternative to no_run is noplayground (https://rust-lang.github.io/mdBook/format/mdbook.html#rust-code-block-attributes), or we could use both (which seems redundant, but is actually what the mdbook docs example uses (https://rust-lang.github.io/mdBook/format/mdbook.html#including-portions-of-a-file).